### PR TITLE
Use Uts46.toUnicode for ENS normalization.

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ function namehash (inputName) {
 }
 
 function normalize(name) {
-  return name ? uts46.toAscii(name, {useStd3ASCII: true, transitional: false}) : name
+  return name ? uts46.toUnicode(name, {useStd3ASCII: true, transitional: false}) : name
 }
 
 exports.hash = namehash

--- a/test/index.js
+++ b/test/index.js
@@ -67,9 +67,25 @@ test('Don\'t normalize international domain', (t) => {
   t.equal(output, expected)
 })
 
-test('Namehash 🇳🇵🇳🇵🇳🇵.eth', (t) => {
+test('Namehash emoji domain', (t) => {
   t.plan(1)
-  const input = '🇳🇵🇳🇵🇳🇵.eth' // emoji https://etherscan.io/address/%F0%9F%87%B3%F0%9F%87%B5%F0%9F%87%B3%F0%9F%87%B5%F0%9F%87%B3%F0%9F%87%B5.eth
+  const input = '🇳🇵🇳🇵🇳🇵.eth' // https://etherscan.io/address/%F0%9F%87%B3%F0%9F%87%B5%F0%9F%87%B3%F0%9F%87%B5%F0%9F%87%B3%F0%9F%87%B5.eth
+  const expected = '0xdfd7de6df978a1995e8239e596a4195d01e43878b8d66850a3e744bf5d136cf6'
+  const output = namehash.hash(input)
+  t.equal(output, expected)
+})
+
+test('Normalize punycode domain to unicode', (t) => {
+  t.plan(1)
+  const input = 'xn--r77haagbb.eth'
+  const expected = '🇳🇵🇳🇵🇳🇵.eth'
+  const output = namehash.normalize(input)
+  t.equal(output, expected)
+})
+
+test('Namehash as punycode domain', (t) => {
+  t.plan(1)
+  const input = 'xn--r77haagbb.eth' // 🇳🇵🇳🇵🇳🇵.eth
   const expected = '0xdfd7de6df978a1995e8239e596a4195d01e43878b8d66850a3e744bf5d136cf6'
   const output = namehash.hash(input)
   t.equal(output, expected)

--- a/test/index.js
+++ b/test/index.js
@@ -43,12 +43,34 @@ test('normalize ascii domain', (t) => {
   t.equal(output, expected)
 })
 
-
-test('normalize international domain', (t) => {
+test('Don\'t normalize international domain', (t) => {
   t.plan(1)
   const input = 'fоо.eth' // with cyrillic 'o'
-  const expected = 'xn--f-1tba.eth'
+  const expected = 'fоо.eth' // with cyrillic 'o'
   const output = namehash.normalize(input)
   t.equal(output, expected)
 })
 
+test('Hash international domain', (t) => {
+  t.plan(1)
+  const input = 'fоо.eth' // with cyrillic 'o'
+  const expected = '0x4ba2c679a3fd1e83c41104c61c8b149647e61d171805ef29338d789509c47be3'
+  const output = namehash.hash(input)
+  t.equal(output, expected)
+})
+
+test('Don\'t normalize international domain', (t) => {
+  t.plan(1)
+  const input = '🇳🇵🇳🇵🇳🇵.eth' // emoji
+  const expected = '🇳🇵🇳🇵🇳🇵.eth'
+  const output = namehash.normalize(input)
+  t.equal(output, expected)
+})
+
+test('Namehash 🇳🇵🇳🇵🇳🇵.eth', (t) => {
+  t.plan(1)
+  const input = '🇳🇵🇳🇵🇳🇵.eth' // emoji https://etherscan.io/address/%F0%9F%87%B3%F0%9F%87%B5%F0%9F%87%B3%F0%9F%87%B5%F0%9F%87%B3%F0%9F%87%B5.eth
+  const expected = '0xdfd7de6df978a1995e8239e596a4195d01e43878b8d66850a3e744bf5d136cf6'
+  const output = namehash.hash(input)
+  t.equal(output, expected)
+})


### PR DESCRIPTION
Added test for 
[🇳🇵🇳🇵🇳🇵.eth](https://etherscan.io/address/%F0%9F%87%B3%F0%9F%87%B5%F0%9F%87%B3%F0%9F%87%B5%F0%9F%87%B3%F0%9F%87%B5.eth): 0xdfd7de6df978a1995e8239e596a4195d01e43878b8d66850a3e744bf5d136cf6


MetaMask/metamask-extension/issues/9129